### PR TITLE
Configuration tweaks to enable build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "wit2wadm.js",
   "scripts": {
     "build:tsc": "tsc",
-    "build:component": "jco componentize -w wit -o dist/wit2wadm.wasm dist/http-hello-world.js",
+    "build:component": "jco componentize -w wit -o dist/wit2wadm.wasm dist/wit2wadm.js",
     "build:actor": "wash build --sign-only --config-path wasmcloud.toml",
     "build": "npm run build:tsc && npm run build:component && npm run build:actor",
     "start": "npm run build && npm run wadm:start",

--- a/wasmcloud.toml
+++ b/wasmcloud.toml
@@ -8,5 +8,5 @@ wit_world = "hello"
 wasm_target = "wasm32-wasi-preview2"
 
 build_command = "npm run build"
-build_artifact = "dist/http-hello-world.wasm"
+build_artifact = "dist/wit2wadm.wasm"
 destination = "build/wit2wadm_ts_s.wasm"


### PR DESCRIPTION
Following the readme, I got this error:

```bash
failed to build actor with custom command: "Error: ENOENT: no such file or directory, open 'dist/http-hello-world.js'\n    at async open (node:internal/fs/promises:633:25)\n    at async readFile (node:internal/fs/promises:1242:14)\n    at async componentize (file:///Users/egregory/wasmcloud/wip/linking/wit2wadm-ts/node_modules/@bytecodealliance/jco/src/cmd/componentize.js:14:18)\n    at async file:///Users/egregory/wasmcloud/wip/linking/wit2wadm-ts/node_modules/@bytecodealliance/jco/src/jco.js:174:9 {\n  errno: -2,\n  code: 'ENOENT',\n  syscall: 'open',\n  path: 'dist/http-hello-world.js'\n}\n"
```

With these tweaks, everything seems to work as expected :)